### PR TITLE
feat(lab): /lab ルート追加とトピック別プレースホルダー (Day 1 #0)

### DIFF
--- a/src/pages/Lab/LabIndex.vue
+++ b/src/pages/Lab/LabIndex.vue
@@ -1,0 +1,79 @@
+<template>
+    <div class="p-8 max-w-4xl mx-auto">
+        <h1 class="text-2xl font-bold mb-4">Lab</h1>
+        <p class="text-gray-600 mb-6">
+            やりたい技術を最小構成で触る砂場。各トピックに独立したページがあります。
+        </p>
+        <ul class="space-y-2">
+            <li v-for="topic in topics" :key="topic.path">
+                <router-link
+                    :to="topic.path"
+                    class="block rounded-md border border-gray-200 p-4 hover:bg-gray-50"
+                >
+                    <div class="font-medium">{{ topic.title }}</div>
+                    <div class="text-sm text-gray-500">{{ topic.summary }}</div>
+                </router-link>
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script setup lang="ts">
+const topics = [
+    {
+        path: "/lab/s3",
+        title: "#1 S3 Presigned Multipart",
+        summary: "Presigned URL + multipart upload",
+    },
+    {
+        path: "/lab/queue",
+        title: "#2 SQS + Worker",
+        summary: "キューイング + 別プロセス worker",
+    },
+    {
+        path: "/lab/fanout",
+        title: "#3 SNS → SQS Fanout",
+        summary: "1 つの publish を複数の worker に配信",
+    },
+    {
+        path: "/lab/lambda",
+        title: "#4 Lambda",
+        summary: "S3 PUT イベントで発火する Go Lambda",
+    },
+    {
+        path: "/lab/cache",
+        title: "#5 Redis Cache-Aside",
+        summary: "Cache-Aside パターンの HIT/MISS 体感",
+    },
+    {
+        path: "/lab/rls",
+        title: "#6 Postgres RLS",
+        summary: "Row Level Security でマルチテナント分離",
+    },
+    {
+        path: "/lab/partition",
+        title: "#7 Postgres パーティショニング",
+        summary: "日付レンジパーティション + EXPLAIN",
+    },
+    {
+        path: "/lab/bulk",
+        title: "#8 Postgres Bulk",
+        summary: "pgx.CopyFrom vs 1 件 INSERT ベンチ",
+    },
+    {
+        path: "/lab/breaker",
+        title: "#9 Circuit Breaker",
+        summary: "gobreaker の状態遷移を可視化",
+    },
+    {
+        path: "/lab/realtime",
+        title: "#10 SSE / WebSocket",
+        summary: "サーバーからリアルタイム push",
+    },
+    {
+        path: "/lab/pprof",
+        title: "#11 pprof",
+        summary: "CPU / heap プロファイル取得",
+    },
+];
+</script>

--- a/src/pages/Lab/LabPlaceholder.vue
+++ b/src/pages/Lab/LabPlaceholder.vue
@@ -1,0 +1,13 @@
+<template>
+    <div class="p-8 max-w-3xl mx-auto">
+        <router-link to="/lab" class="text-sm text-blue-600 hover:underline">
+            ← Lab トップへ
+        </router-link>
+        <h1 class="mt-4 text-2xl font-bold">{{ title }}</h1>
+        <p class="mt-2 text-gray-500">このトピックはまだ未実装です。</p>
+    </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ title: string }>();
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -22,6 +22,9 @@ import TagDetail from "../pages/TagDetail/TagDetail.vue";
 
 import Signup from "../pages/Signup/Signup.vue";
 
+import LabIndex from "../pages/Lab/LabIndex.vue";
+import LabPlaceholder from "../pages/Lab/LabPlaceholder.vue";
+
 import Error from "../pages/Error/Error.vue";
 import { createAxiosInstance } from "@/utils/axiosinstance";
 import { useMeStore } from "@/store/me";
@@ -183,6 +186,77 @@ const routes: RouteRecordRaw[] = [
             requiresAuth: true,
             allowedRoles: [userRole.Admin],
         },
+    },
+    {
+        path: "/lab",
+        name: "LabIndex",
+        component: LabIndex,
+    },
+    {
+        path: "/lab/s3",
+        name: "LabS3",
+        component: LabPlaceholder,
+        props: { title: "#1 S3 Presigned Multipart" },
+    },
+    {
+        path: "/lab/queue",
+        name: "LabQueue",
+        component: LabPlaceholder,
+        props: { title: "#2 SQS + Worker" },
+    },
+    {
+        path: "/lab/fanout",
+        name: "LabFanout",
+        component: LabPlaceholder,
+        props: { title: "#3 SNS → SQS Fanout" },
+    },
+    {
+        path: "/lab/lambda",
+        name: "LabLambda",
+        component: LabPlaceholder,
+        props: { title: "#4 Lambda" },
+    },
+    {
+        path: "/lab/cache",
+        name: "LabCache",
+        component: LabPlaceholder,
+        props: { title: "#5 Redis Cache-Aside" },
+    },
+    {
+        path: "/lab/rls",
+        name: "LabRls",
+        component: LabPlaceholder,
+        props: { title: "#6 Postgres RLS" },
+    },
+    {
+        path: "/lab/partition",
+        name: "LabPartition",
+        component: LabPlaceholder,
+        props: { title: "#7 Postgres パーティショニング" },
+    },
+    {
+        path: "/lab/bulk",
+        name: "LabBulk",
+        component: LabPlaceholder,
+        props: { title: "#8 Postgres Bulk" },
+    },
+    {
+        path: "/lab/breaker",
+        name: "LabBreaker",
+        component: LabPlaceholder,
+        props: { title: "#9 Circuit Breaker" },
+    },
+    {
+        path: "/lab/realtime",
+        name: "LabRealtime",
+        component: LabPlaceholder,
+        props: { title: "#10 SSE / WebSocket" },
+    },
+    {
+        path: "/lab/pprof",
+        name: "LabPprof",
+        component: LabPlaceholder,
+        props: { title: "#11 pprof" },
     },
     {
         path: "/error",


### PR DESCRIPTION
## Summary
lab カリキュラム Day 1 #0: UI 側の骨格。トピック別ページのルーティングとプレースホルダー。

## 追加内容
- **src/pages/Lab/LabIndex.vue**: 11 トピックの一覧ページ
- **src/pages/Lab/LabPlaceholder.vue**: 「未実装」を表示する汎用ページ
- **src/router/index.ts**: `/lab` と `/lab/<topic>` のルート 12 個を追加。認証不要

## Test plan
- [x] http://localhost:5173/lab でトピック一覧が表示される
- [x] 各 `/lab/<topic>` リンクがプレースホルダーを表示する
- [x] 既存ページへの影響なし（signup/login 等は変更なし）

## 次
各トピック実装時にプレースホルダーを置き換える。