### PR TITLE
feat(lab): /lab/s3 に S3 presigned single PUT UI を実装

### DIFF
--- a/src/pages/Lab/LabS3.vue
+++ b/src/pages/Lab/LabS3.vue
@@ -1,0 +1,266 @@
+<template>
+    <div class="p-8 max-w-3xl mx-auto">
+        <router-link
+            to="/lab"
+            class="text-sm text-blue-600 hover:underline"
+        >
+            ← Lab トップへ
+        </router-link>
+        <h1 class="mt-4 text-2xl font-bold">#1 S3 Presigned Multipart</h1>
+        <p class="mt-2 text-sm text-gray-500">
+            ファイルを {{ PART_MIB }}MiB の chunk に分割し、パートごとに
+            presigned URL を取得してブラウザから直接 S3 (LocalStack) に PUT
+            する。最後に ETag を集めて CompleteMultipartUpload。
+        </p>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <h2 class="font-semibold">アップロード</h2>
+            <div class="mt-3 flex items-center gap-3">
+                <input
+                    type="file"
+                    class="text-sm"
+                    @change="onFileChange"
+                />
+                <button
+                    type="button"
+                    class="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                    :disabled="!file || uploading"
+                    @click="upload"
+                >
+                    {{ uploading ? "アップロード中…" : "アップロード" }}
+                </button>
+            </div>
+
+            <div
+                v-if="file"
+                class="mt-3 text-xs text-gray-600"
+            >
+                選択中: {{ file.name }} ({{ humanSize(file.size) }},
+                パート数 {{ totalParts }})
+            </div>
+
+            <div
+                v-if="uploading || progress > 0"
+                class="mt-4"
+            >
+                <div class="h-2 w-full overflow-hidden rounded bg-gray-200">
+                    <div
+                        class="h-full bg-blue-500 transition-all"
+                        :style="{ width: progress + '%' }"
+                    />
+                </div>
+                <div class="mt-1 text-xs text-gray-500">
+                    {{ progress.toFixed(1) }}%
+                    ({{ completedParts }}/{{ totalParts }} parts)
+                </div>
+            </div>
+
+            <ul
+                v-if="log.length"
+                class="mt-4 max-h-48 overflow-auto rounded bg-gray-50 p-2 text-xs font-mono"
+            >
+                <li
+                    v-for="(line, i) in log"
+                    :key="i"
+                    :class="line.level === 'error' ? 'text-red-600' : 'text-gray-700'"
+                >
+                    [{{ line.level }}] {{ line.msg }}
+                </li>
+            </ul>
+        </section>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <div class="flex items-center justify-between">
+                <h2 class="font-semibold">アップロード済みファイル</h2>
+                <button
+                    type="button"
+                    class="text-xs text-blue-600 hover:underline"
+                    @click="loadObjects"
+                >
+                    再読込
+                </button>
+            </div>
+            <table class="mt-3 w-full text-sm">
+                <thead class="text-left text-xs text-gray-500">
+                    <tr>
+                        <th class="py-1">key</th>
+                        <th class="py-1">size</th>
+                        <th class="py-1">lastModified</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr
+                        v-for="obj in objects"
+                        :key="obj.key"
+                        class="border-t border-gray-100"
+                    >
+                        <td class="py-1 font-mono text-xs">{{ obj.key }}</td>
+                        <td class="py-1">{{ humanSize(obj.size) }}</td>
+                        <td class="py-1 text-xs text-gray-500">
+                            {{ obj.lastModified }}
+                        </td>
+                    </tr>
+                    <tr v-if="!objects.length">
+                        <td
+                            class="py-2 text-xs text-gray-400"
+                            colspan="3"
+                        >
+                            まだアップロードされていません。
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import axios from "axios";
+
+// S3 multipart は非最終パートに 5MiB 下限がある。
+const PART_MIB = 5;
+const PART_SIZE = PART_MIB * 1024 * 1024;
+
+type LabObject = { key: string; size: number; lastModified: string };
+type LogLine = { level: "info" | "error"; msg: string };
+
+const apiBase = import.meta.env.VITE_APP_API_BASE_URL as string;
+
+const file = ref<File | null>(null);
+const uploading = ref(false);
+const completedParts = ref(0);
+const objects = ref<LabObject[]>([]);
+const log = ref<LogLine[]>([]);
+
+const totalParts = computed(() =>
+    file.value ? Math.max(1, Math.ceil(file.value.size / PART_SIZE)) : 0
+);
+const progress = computed(() =>
+    totalParts.value === 0
+        ? 0
+        : (completedParts.value / totalParts.value) * 100
+);
+
+const onFileChange = (e: Event) => {
+    const input = e.target as HTMLInputElement;
+    file.value = input.files?.[0] ?? null;
+    completedParts.value = 0;
+    log.value = [];
+};
+
+const pushLog = (level: LogLine["level"], msg: string) => {
+    log.value.push({ level, msg });
+};
+
+const humanSize = (n: number) => {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+    if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MiB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)} GiB`;
+};
+
+const loadObjects = async () => {
+    const { data } = await axios.get(`${apiBase}/lab/s3/objects`);
+    objects.value = data.objects ?? [];
+};
+
+const upload = async () => {
+    if (!file.value) return;
+    const f = file.value;
+
+    uploading.value = true;
+    completedParts.value = 0;
+    log.value = [];
+
+    let uploadId = "";
+    let key = "";
+    try {
+        pushLog("info", `CreateMultipartUpload: ${f.name} (${humanSize(f.size)})`);
+        const createRes = await axios.post(`${apiBase}/lab/s3/multipart/create`, {
+            filename: f.name,
+            contentType: f.type || "application/octet-stream",
+        });
+        uploadId = createRes.data.uploadId;
+        key = createRes.data.key;
+        pushLog("info", `uploadId=${uploadId.slice(0, 12)}... key=${key}`);
+
+        const parts: { partNumber: number; eTag: string }[] = [];
+        for (let i = 0; i < totalParts.value; i++) {
+            const partNumber = i + 1;
+            const start = i * PART_SIZE;
+            const end = Math.min(start + PART_SIZE, f.size);
+            const chunk = f.slice(start, end);
+
+            const signRes = await axios.post(
+                `${apiBase}/lab/s3/multipart/sign-part`,
+                { key, uploadId, partNumber }
+            );
+            const url: string = signRes.data.url;
+
+            const putRes = await fetch(url, {
+                method: "PUT",
+                body: chunk,
+            });
+            if (!putRes.ok) {
+                throw new Error(
+                    `PUT part ${partNumber} failed: HTTP ${putRes.status}`
+                );
+            }
+            const etag = (
+                putRes.headers.get("ETag") ||
+                putRes.headers.get("etag") ||
+                ""
+            ).replace(/^"|"$/g, "");
+            if (!etag) {
+                throw new Error(
+                    `part ${partNumber}: ETag not exposed (check S3 CORS ExposeHeaders)`
+                );
+            }
+            parts.push({ partNumber, eTag: etag });
+            completedParts.value = partNumber;
+            pushLog(
+                "info",
+                `PUT part ${partNumber}/${totalParts.value} etag=${etag.slice(0, 8)}...`
+            );
+        }
+
+        pushLog("info", `CompleteMultipartUpload (${parts.length} parts)`);
+        const completeRes = await axios.post(
+            `${apiBase}/lab/s3/multipart/complete`,
+            { key, uploadId, parts }
+        );
+        pushLog("info", `done: ${completeRes.data.location}`);
+        await loadObjects();
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        pushLog("error", msg);
+        if (uploadId && key) {
+            try {
+                await axios.post(`${apiBase}/lab/s3/multipart/abort`, {
+                    key,
+                    uploadId,
+                });
+                pushLog("info", "AbortMultipartUpload: 中断済み");
+            } catch (abortErr) {
+                const am =
+                    abortErr instanceof Error
+                        ? abortErr.message
+                        : String(abortErr);
+                pushLog("error", `abort failed: ${am}`);
+            }
+        }
+    } finally {
+        uploading.value = false;
+    }
+};
+
+onMounted(() => {
+    loadObjects().catch((e) => {
+        pushLog(
+            "error",
+            `list failed: ${e instanceof Error ? e.message : String(e)}`
+        );
+    });
+});
+</script>

--- a/src/pages/Lab/LabS3.vue
+++ b/src/pages/Lab/LabS3.vue
@@ -6,11 +6,12 @@
         >
             ← Lab トップへ
         </router-link>
-        <h1 class="mt-4 text-2xl font-bold">#1 S3 Presigned Multipart</h1>
+        <h1 class="mt-4 text-2xl font-bold">#1 S3 Presigned PUT</h1>
         <p class="mt-2 text-sm text-gray-500">
-            ファイルを {{ PART_MIB }}MiB の chunk に分割し、パートごとに
-            presigned URL を取得してブラウザから直接 S3 (LocalStack) に PUT
-            する。最後に ETag を集めて CompleteMultipartUpload。
+            backend から発行した presigned URL に対してブラウザが
+            ファイル全体を 1 回の PUT で送る single upload 方式。
+            B2B SaaS の請求書・経費系（&lt; 100 MB 想定）なら multipart を
+            避けて実装を最小化できる。
         </p>
 
         <section class="mt-6 rounded-md border border-gray-200 p-4">
@@ -35,8 +36,7 @@
                 v-if="file"
                 class="mt-3 text-xs text-gray-600"
             >
-                選択中: {{ file.name }} ({{ humanSize(file.size) }},
-                パート数 {{ totalParts }})
+                選択中: {{ file.name }} ({{ humanSize(file.size) }})
             </div>
 
             <div
@@ -51,7 +51,6 @@
                 </div>
                 <div class="mt-1 text-xs text-gray-500">
                     {{ progress.toFixed(1) }}%
-                    ({{ completedParts }}/{{ totalParts }} parts)
                 </div>
             </div>
 
@@ -118,10 +117,6 @@
 import { computed, onMounted, ref } from "vue";
 import axios from "axios";
 
-// S3 multipart は非最終パートに 5MiB 下限がある。
-const PART_MIB = 5;
-const PART_SIZE = PART_MIB * 1024 * 1024;
-
 type LabObject = { key: string; size: number; lastModified: string };
 type LogLine = { level: "info" | "error"; msg: string };
 
@@ -129,23 +124,20 @@ const apiBase = import.meta.env.VITE_APP_API_BASE_URL as string;
 
 const file = ref<File | null>(null);
 const uploading = ref(false);
-const completedParts = ref(0);
+const uploadedBytes = ref(0);
 const objects = ref<LabObject[]>([]);
 const log = ref<LogLine[]>([]);
 
-const totalParts = computed(() =>
-    file.value ? Math.max(1, Math.ceil(file.value.size / PART_SIZE)) : 0
-);
 const progress = computed(() =>
-    totalParts.value === 0
-        ? 0
-        : (completedParts.value / totalParts.value) * 100
+    file.value && file.value.size > 0
+        ? (uploadedBytes.value / file.value.size) * 100
+        : 0
 );
 
 const onFileChange = (e: Event) => {
     const input = e.target as HTMLInputElement;
     file.value = input.files?.[0] ?? null;
-    completedParts.value = 0;
+    uploadedBytes.value = 0;
     log.value = [];
 };
 
@@ -170,86 +162,54 @@ const upload = async () => {
     const f = file.value;
 
     uploading.value = true;
-    completedParts.value = 0;
+    uploadedBytes.value = 0;
     log.value = [];
 
-    let uploadId = "";
-    let key = "";
     try {
-        pushLog("info", `CreateMultipartUpload: ${f.name} (${humanSize(f.size)})`);
-        const createRes = await axios.post(`${apiBase}/lab/s3/multipart/create`, {
-            filename: f.name,
-            contentType: f.type || "application/octet-stream",
-        });
-        uploadId = createRes.data.uploadId;
-        key = createRes.data.key;
-        pushLog("info", `uploadId=${uploadId.slice(0, 12)}... key=${key}`);
-
-        const parts: { partNumber: number; eTag: string }[] = [];
-        for (let i = 0; i < totalParts.value; i++) {
-            const partNumber = i + 1;
-            const start = i * PART_SIZE;
-            const end = Math.min(start + PART_SIZE, f.size);
-            const chunk = f.slice(start, end);
-
-            const signRes = await axios.post(
-                `${apiBase}/lab/s3/multipart/sign-part`,
-                { key, uploadId, partNumber }
-            );
-            const url: string = signRes.data.url;
-
-            const putRes = await fetch(url, {
-                method: "PUT",
-                body: chunk,
-            });
-            if (!putRes.ok) {
-                throw new Error(
-                    `PUT part ${partNumber} failed: HTTP ${putRes.status}`
-                );
-            }
-            const etag = (
-                putRes.headers.get("ETag") ||
-                putRes.headers.get("etag") ||
-                ""
-            ).replace(/^"|"$/g, "");
-            if (!etag) {
-                throw new Error(
-                    `part ${partNumber}: ETag not exposed (check S3 CORS ExposeHeaders)`
-                );
-            }
-            parts.push({ partNumber, eTag: etag });
-            completedParts.value = partNumber;
-            pushLog(
-                "info",
-                `PUT part ${partNumber}/${totalParts.value} etag=${etag.slice(0, 8)}...`
-            );
-        }
-
-        pushLog("info", `CompleteMultipartUpload (${parts.length} parts)`);
-        const completeRes = await axios.post(
-            `${apiBase}/lab/s3/multipart/complete`,
-            { key, uploadId, parts }
+        pushLog(
+            "info",
+            `presign-put: ${f.name} (${humanSize(f.size)}, ${f.type || "application/octet-stream"})`
         );
-        pushLog("info", `done: ${completeRes.data.location}`);
+        const { data } = await axios.post(
+            `${apiBase}/lab/s3/presign-put`,
+            {
+                filename: f.name,
+                contentType: f.type || "application/octet-stream",
+            }
+        );
+        const url: string = data.url;
+        const key: string = data.key;
+        pushLog("info", `key=${key}`);
+
+        // XMLHttpRequest を使うのは fetch だと upload.onprogress 相当の
+        // 進捗イベントが取れないため（fetch streams は未サポートなブラウザあり）。
+        // axios に任せる手もあるが、axios は Content-Type を自動で付けるため
+        // 署名と不一致を起こすリスクがある → 生 XHR を使う。
+        await new Promise<void>((resolve, reject) => {
+            const xhr = new XMLHttpRequest();
+            xhr.open("PUT", url);
+            xhr.upload.onprogress = (ev) => {
+                if (ev.lengthComputable) {
+                    uploadedBytes.value = ev.loaded;
+                }
+            };
+            xhr.onload = () => {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    uploadedBytes.value = f.size;
+                    resolve();
+                } else {
+                    reject(new Error(`PUT failed: HTTP ${xhr.status}`));
+                }
+            };
+            xhr.onerror = () => reject(new Error("PUT network error"));
+            xhr.send(f);
+        });
+
+        pushLog("info", "upload done");
         await loadObjects();
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         pushLog("error", msg);
-        if (uploadId && key) {
-            try {
-                await axios.post(`${apiBase}/lab/s3/multipart/abort`, {
-                    key,
-                    uploadId,
-                });
-                pushLog("info", "AbortMultipartUpload: 中断済み");
-            } catch (abortErr) {
-                const am =
-                    abortErr instanceof Error
-                        ? abortErr.message
-                        : String(abortErr);
-                pushLog("error", `abort failed: ${am}`);
-            }
-        }
     } finally {
         uploading.value = false;
     }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,6 +24,7 @@ import Signup from "../pages/Signup/Signup.vue";
 
 import LabIndex from "../pages/Lab/LabIndex.vue";
 import LabPlaceholder from "../pages/Lab/LabPlaceholder.vue";
+import LabS3 from "../pages/Lab/LabS3.vue";
 
 import Error from "../pages/Error/Error.vue";
 import { createAxiosInstance } from "@/utils/axiosinstance";
@@ -195,8 +196,7 @@ const routes: RouteRecordRaw[] = [
     {
         path: "/lab/s3",
         name: "LabS3",
-        component: LabPlaceholder,
-        props: { title: "#1 S3 Presigned Multipart" },
+        component: LabS3,
     },
     {
         path: "/lab/queue",


### PR DESCRIPTION
## 実装概要

Lab 第 1 弾の UI 実装。`/lab/s3` にて、backend が発行した presigned URL に対してブラウザから **1 回の PUT でファイル全体を送る** single upload 方式。バックエンドは [fanc-api PR #73](https://github.com/kudotaka0421/fanc-api/pull/73)。

> 📚 方式選択の背景（A/B/C 比較、なぜ B を選んだか）は `~/.claude/docs/interview/system-design/file-upload-patterns.md`。

### 変更ファイル

- `src/pages/Lab/LabS3.vue` — 新規ページ（ファイル選択・進捗バー・ログ・一覧テーブル）
- `src/router/index.ts` — `/lab/s3` を `LabPlaceholder` から `LabS3` に差し替え

### 画面構成

- **アップロード枠**: file input、進捗バー（バイト単位）、操作ログ
- **一覧枠**: `GET /lab/s3/objects` から取得したアップロード済みファイル、「再読込」ボタン

## 設計判断の「なぜ」

### なぜ XHR で PUT しているか（fetch でも axios でもなく）

- **axios は勝手に `Content-Type` を自動付与する**ケースがあり、**S3 の presigned URL の署名対象ヘッダーと不一致になると 403** になる
- **fetch** はヘッダーを追加しないので署名と整合するが、**upload progress イベントが取れない**（fetch streams は未サポートブラウザあり）
- **XMLHttpRequest** は素朴だが `xhr.upload.onprogress` でバイト単位の進捗が確実に取れる

lab の要件「進捗バーを見せる」を満たすため XHR にした。本番で `Upload` クラス（aws-sdk-js）に切替える場合も内部は XHR ベースなので考え方は同じ。

### なぜ multipart に切り替えずに single PUT で実装したか

前バージョン（PR 初版）は multipart で実装していたが、B2B SaaS（バクラク系）の実ファイルサイズは 99 % が < 100 MB で multipart の恩恵が出る場面が稀。コード削減の判断で single PUT に書き換えた。

| 指標 | 書き換え前（multipart）| 書き換え後（single PUT）|
|---|---|---|
| UI ロジック | chunk 分割・ETag 集計・abort ハンドラ | 1 発 PUT |
| エラー処理 | 失敗パート再送 / abort 呼び出し | リトライのみ |
| FE の行数 | ~240 | ~160 |
| 進捗単位 | パート単位（離散的に跳ねる）| バイト単位（なめらか）|

### なぜ進捗をバイト単位にしたか

single PUT なので「何パート完了」では表現できない。`xhr.upload.onprogress` の `event.loaded / event.total` で 0〜100 % をなめらかに表示する。本番 UX でもこちらのほうが好まれる。

## ハマりポイント・注意事項

### 1. CORS で PUT を許可する

前 PR（multipart）で `AllowedMethods: [PUT, GET, HEAD, POST]` を設定済み。single PUT でも PUT が効いていれば OK。ExposeHeaders は single では不要（ETag を FE で読まない）。

### 2. axios 禁止ではなく「PUT のみ axios を使わない」

POST (`/presign-put`) は axios でよい。PUT だけ XHR。理由は上記のとおり署名ヘッダー不一致回避。

### 3. presigned URL の有効期限切れ

発行から 15 分を超えると S3 が 403 を返す。大容量 × 遅い回線だと切れる可能性があるので、本番で大きいファイルを扱うなら有効期限を長くする or 切れたら再発行するリトライロジックを入れる。

## 本番 AWS との差分・設定箇所

フロントエンド側は **コード変更なしで本番動作する**。本番移行時に変更が必要なのは:

- `.env.production` の `VITE_APP_API_BASE_URL` を本番 API URL に
- S3 bucket CORS の `allowed_origins` を `["https://fanc.example.com"]` に絞る（Terraform）
- presigned URL の有効期限（5〜15 分）と、期限切れ検出 & 再発行ロジックの追加検討

## 面接で話せるポイント

- **presigned URL で backend を経由しない理由**: backend のスループット・メモリを consume しない、ブラウザ → S3 直通で速い・安い
- **XHR の選択理由**: axios の自動ヘッダー付与と S3 署名の不一致問題
- **本番 UX**: アップロード中のタブ閉じ警告、再開（resumable）が必要なら C（multipart）に切替
- **セキュリティ境界**: presigned URL は短期トークン。URL 発行前に認可・MIME・サイズ上限を backend で検証する。発行後は誰が何を PUT しても S3 はチェックしないため
- **失敗観測**: CloudWatch + S3 Access Logs で 4xx/5xx の発生率を監視

## Test plan

- [x] `npm run build` が通る（vue-tsc + vite build）
- [x] `/lab/s3` が表示される
- [x] ファイルを選択 → 「アップロード」押下
- [x] 進捗バーが 0 → 100 % にバイト単位で進む
- [x] 「アップロード済みファイル」にエントリが追加される
- [x] 小さいファイル（数 KB）でも動く
- [ ] 大容量ファイル（50+ MB）での PUT の UX を確認
- [ ] Network throttle で途中切断時の挙動を観察

### 関連 PR

- Backend: [fanc-api#73](https://github.com/kudotaka0421/fanc-api/pull/73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
