### PR TITLE
feat(lab): /lab/queue に SQS + Worker の UI を実装

### DIFF
--- a/src/pages/Lab/LabQueue.vue
+++ b/src/pages/Lab/LabQueue.vue
@@ -1,0 +1,221 @@
+<template>
+    <div class="p-8 max-w-3xl mx-auto">
+        <router-link
+            to="/lab"
+            class="text-sm text-blue-600 hover:underline"
+        >
+            ← Lab トップへ
+        </router-link>
+        <h1 class="mt-4 text-2xl font-bold">#2 SQS + Worker</h1>
+        <p class="mt-2 text-sm text-gray-500">
+            POST された本文を SQS `lab-primary` に publish。別コンテナで動く
+            worker プロセスが long polling で受信し、1 秒のダミー処理後に
+            DeleteMessage。本文に
+            <code class="rounded bg-gray-100 px-1">fail</code>
+            を含む場合は削除せず、visibility timeout (10s) 切れによる
+            再配信 × 3 回後に DLQ へ移動する（redrive policy）。
+        </p>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <h2 class="font-semibold">Publish</h2>
+            <textarea
+                v-model="messageBody"
+                class="mt-2 w-full rounded border border-gray-300 p-2 font-mono text-sm"
+                rows="2"
+                placeholder="任意のメッセージ本文"
+            ></textarea>
+            <div class="mt-2 flex flex-wrap gap-2">
+                <button
+                    type="button"
+                    class="rounded bg-blue-600 px-4 py-2 text-sm text-white disabled:opacity-50"
+                    :disabled="!messageBody || busy"
+                    @click="publish(messageBody)"
+                >
+                    送信
+                </button>
+                <button
+                    type="button"
+                    class="rounded bg-orange-500 px-4 py-2 text-sm text-white disabled:opacity-50"
+                    :disabled="busy"
+                    @click="publishFail"
+                >
+                    fail 付きで送信（DLQ 行き確認用）
+                </button>
+                <button
+                    type="button"
+                    class="rounded bg-gray-600 px-4 py-2 text-sm text-white disabled:opacity-50"
+                    :disabled="busy"
+                    @click="publishBurst"
+                >
+                    10 件 burst
+                </button>
+            </div>
+        </section>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <div class="flex items-center justify-between">
+                <h2 class="font-semibold">Queue Stats</h2>
+                <label class="text-xs text-gray-600">
+                    <input
+                        v-model="autoRefresh"
+                        type="checkbox"
+                        class="mr-1"
+                    />
+                    auto-refresh (2s)
+                </label>
+            </div>
+            <table class="mt-3 w-full text-sm">
+                <thead class="text-left text-xs text-gray-500">
+                    <tr>
+                        <th class="py-1">queue</th>
+                        <th class="py-1 text-right">visible</th>
+                        <th class="py-1 text-right">inFlight</th>
+                        <th class="py-1 text-right">delayed</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="border-t border-gray-100">
+                        <td class="py-1 font-mono text-xs">lab-primary</td>
+                        <td class="py-1 text-right">
+                            {{ stats?.primary?.visible ?? "-" }}
+                        </td>
+                        <td class="py-1 text-right">
+                            {{ stats?.primary?.inFlight ?? "-" }}
+                        </td>
+                        <td class="py-1 text-right">
+                            {{ stats?.primary?.delayed ?? "-" }}
+                        </td>
+                    </tr>
+                    <tr class="border-t border-gray-100">
+                        <td class="py-1 font-mono text-xs">lab-dlq</td>
+                        <td class="py-1 text-right">
+                            {{ stats?.dlq?.visible ?? "-" }}
+                        </td>
+                        <td class="py-1 text-right">
+                            {{ stats?.dlq?.inFlight ?? "-" }}
+                        </td>
+                        <td class="py-1 text-right">
+                            {{ stats?.dlq?.delayed ?? "-" }}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <p class="mt-2 text-xs text-gray-400">
+                ApproximateNumberOfMessages 系の値は結果整合性なので、数秒の
+                遅れがある。
+            </p>
+        </section>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <h2 class="font-semibold">Log</h2>
+            <ul
+                class="mt-2 max-h-48 overflow-auto rounded bg-gray-50 p-2 font-mono text-xs"
+            >
+                <li
+                    v-for="(line, i) in log"
+                    :key="i"
+                    :class="
+                        line.level === 'error'
+                            ? 'text-red-600'
+                            : 'text-gray-700'
+                    "
+                >
+                    [{{ line.level }}] {{ line.msg }}
+                </li>
+                <li
+                    v-if="!log.length"
+                    class="text-gray-400"
+                >
+                    publish するとここにログが出ます
+                </li>
+            </ul>
+        </section>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from "vue";
+import axios from "axios";
+
+type QueueAttr = { visible: number; inFlight: number; delayed: number };
+type Stats = { primary: QueueAttr; dlq: QueueAttr };
+type LogLine = { level: "info" | "error"; msg: string };
+
+const apiBase = import.meta.env.VITE_APP_API_BASE_URL as string;
+
+const messageBody = ref("hello from lab");
+const stats = ref<Stats | null>(null);
+const log = ref<LogLine[]>([]);
+const busy = ref(false);
+const autoRefresh = ref(true);
+let timer: number | undefined;
+
+const pushLog = (level: LogLine["level"], msg: string) => {
+    log.value.unshift({ level, msg });
+    if (log.value.length > 50) log.value.pop();
+};
+
+const loadStats = async () => {
+    try {
+        const { data } = await axios.get(`${apiBase}/lab/sqs/stats`);
+        stats.value = data;
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        pushLog("error", `stats: ${msg}`);
+    }
+};
+
+const publish = async (body: string) => {
+    busy.value = true;
+    try {
+        const { data } = await axios.post(`${apiBase}/lab/sqs/publish`, {
+            body,
+        });
+        pushLog(
+            "info",
+            `publish ok: ${data.messageId.slice(0, 12)}... body=${body}`
+        );
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        pushLog("error", `publish: ${msg}`);
+    } finally {
+        busy.value = false;
+    }
+    await loadStats();
+};
+
+const publishFail = async () => {
+    const body = `fail ${new Date().toISOString()}`;
+    await publish(body);
+};
+
+const publishBurst = async () => {
+    busy.value = true;
+    try {
+        const requests = Array.from({ length: 10 }, (_, i) =>
+            axios.post(`${apiBase}/lab/sqs/publish`, {
+                body: `burst-${i} ${new Date().toISOString()}`,
+            })
+        );
+        await Promise.all(requests);
+        pushLog("info", "burst: 10 件 publish 完了");
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        pushLog("error", `burst: ${msg}`);
+    } finally {
+        busy.value = false;
+    }
+    await loadStats();
+};
+
+onMounted(() => {
+    loadStats();
+    timer = window.setInterval(() => {
+        if (autoRefresh.value) loadStats();
+    }, 2000);
+});
+
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
+});
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -25,6 +25,7 @@ import Signup from "../pages/Signup/Signup.vue";
 import LabIndex from "../pages/Lab/LabIndex.vue";
 import LabPlaceholder from "../pages/Lab/LabPlaceholder.vue";
 import LabS3 from "../pages/Lab/LabS3.vue";
+import LabQueue from "../pages/Lab/LabQueue.vue";
 
 import Error from "../pages/Error/Error.vue";
 import { createAxiosInstance } from "@/utils/axiosinstance";
@@ -201,8 +202,7 @@ const routes: RouteRecordRaw[] = [
     {
         path: "/lab/queue",
         name: "LabQueue",
-        component: LabPlaceholder,
-        props: { title: "#2 SQS + Worker" },
+        component: LabQueue,
     },
     {
         path: "/lab/fanout",


### PR DESCRIPTION
> ⚠️ **stacked PR**: base は `feature/lab-s3-multipart`（#105）。#105 マージ後に base を develop に付け替えてください。

## 実装概要

Lab 第 2 弾の UI 実装。`/lab/queue` で SQS へのメッセージ送信と、queue depth の観察ができる画面を作った。バックエンドは [fanc-api PR #74](https://github.com/kudotaka0421/fanc-api/pull/74)。

### 変更ファイル

- `src/pages/Lab/LabQueue.vue` — 新規ページ（publish フォーム・stats テーブル・ログパネル）
- `src/router/index.ts` — `/lab/queue` を `LabPlaceholder` から `LabQueue` に差し替え

### 画面構成

| セクション | 内容 |
|---|---|
| Publish | textarea + 3 つのボタン: 「送信」「fail 付き送信（DLQ 行き確認用）」「10件 burst」 |
| Queue Stats | lab-primary / lab-dlq の `visible` / `inFlight` / `delayed` を 2 秒おき auto-refresh |
| Log | 最近の publish 結果・エラーを直近 50 件表示 |

## 設計判断の「なぜ」

### なぜ 3 種類のボタンか

SQS の挙動を UI から見せるには以下の 3 シナリオをワンクリックで出せると便利:

1. **正常系** (「送信」): publish → worker が受信 → 削除 → stats が 0 に戻る流れ
2. **DLQ 行き** (「fail 付き送信」): worker が削除を skip → 10s × 3 回で DLQ へ移動
3. **burst** (「10件 burst」): inFlight が一瞬で増える様子、worker が順次処理していく

教材として、ボタン 1 つでトリガーできる状態にしておくと触って理解しやすい。

### なぜ `auto-refresh` をチェックボックスで on/off 可能にしたか

ApproximateNumberOfMessages が結果整合で、2 秒ごとに動き続けると観察しづらいケースがある（例: DLQ に移動する瞬間のスナップショットを見たい）。off にすれば任意のタイミングの値で止められる。

### なぜ stats 専用 API を 1 本にまとめたか

primary と dlq の 2 回呼び分けてもよかったが、フロント側で 2 つの Promise を待ち合わせるより「サーバー側で 2 本の GetQueueAttributes を内部で叩き 1 レスポンスにまとめる」方がフロント実装が単純。バックエンド PR ではこの設計で実装済み。

### なぜ burst publish を `Promise.all` にしたか

逐次（for + await）だと 10 件送るのに 200〜500ms かかり、burst というより点送に見える。`Promise.all` で同時 10 並列で投げると文字通り「bust」で inFlight が一気に積み上がる様子が観察できる。

## ハマりポイント・注意事項

### 1. stats の値がぶれる

`ApproximateNumberOfMessages` は結果整合で、publish 直後に 0 が返ることがある。**本番でもこの挙動なので、UI で 100% 正確な値を見せるのは諦める設計** が正しい（「だいたい何件ある」が分かれば運用は成立する）。

### 2. `visible` と `inFlight` の違いは触って覚える

- `visible`: まだ受信されていない = 誰も取っていない
- `inFlight`: 受信済みで visibility timeout 内 = 処理中
- `delayed`: delay queue で遅延配送待ち

ボタンを押して 2 秒ポーリングで数値が動くので、どれがどう動くかは触ると分かる。

### 3. axios の interceptor にトークンが入ると無駄に Authorization ヘッダが付く

fanc-front の `axiosinstance` は localStorage のトークン有無でインスタンスを切り替える。`/api/lab/*` は認証不要だが、ログイン済みなら token が付いて送られる（特に問題にはならないが、fail デバッグ時に「これの影響か？」と疑いがち）。

### 4. auto-refresh タイマーのクリーンアップ

`onUnmounted` で `clearInterval` を確実に呼ぶ。Vue の SPA は画面遷移でコンポーネントが破棄されるが、setInterval はグローバルに残り続けるので、複数ページを行き来するとタイマーが増殖してリクエストが倍々に増える。

## 本番 AWS との差分・設定箇所

フロント側の **コードは本番でも一切変更不要**。

- API ベース URL: `.env.production` で本番 API Gateway を指す
- stats 表示: CloudWatch の `ApproximateNumberOfMessagesVisible` を使う発想と同じだが、本番では Grafana や CloudWatch Dashboard で見るのが普通
- 本番 UI に組み込むなら: 運用ダッシュボードとして残す or 開発者向けのデバッグページとして閉じた URL に隠す

## 面接で話せるポイント

- **フロントから直接 SQS に投げない理由**: AWS credentials を配れない、認可ロジックを backend に集中したい、publish と business logic を密結合にしたいケースが多い
- **queue depth の観察を UI に出すのは？**: 一般ユーザー向けには不要（内部状態）、社内オペレーター向け/デバッグ用には役立つ
- **バックエンドが ReceiveMessage をしない（worker に分離）**: UI レスポンス時間を予測可能に保つ、worker の障害が API に波及しない
- **publish API が GET でなく POST の理由**: 副作用を伴う、冪等性がない、キャッシュされるべきでない（HTTP メソッド選択の基本原則に従う）
- **burst 時の backpressure**: フロントの Promise.all は 10 並列だが、本番で何千並列になると API に負荷がかかる。backend 側でレート制限 or フロントで semaphore パターンを使う

## Test plan

- [x] `npm run build` (vue-tsc + vite build) 通る
- [x] `/lab/queue` が表示される
- [x] 「送信」→ 数秒後に stats が 0 に戻る
- [x] 「fail 付き送信」→ ~40 秒後 DLQ visible=1
- [x] 「10件 burst」→ inFlight が跳ね、順次処理で減る
- [x] auto-refresh off で値が固定される
- [ ] 複数タブで同時に publish した時の挙動

### 関連 PR

- Backend: [fanc-api#74](https://github.com/kudotaka0421/fanc-api/pull/74)
- Depends on: #105 (Lab scaffolding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
