### PR TITLE
feat(lab): /lab/fanout に SNS → SQS Fanout の UI を実装

### DIFF
--- a/src/pages/Lab/LabFanout.vue
+++ b/src/pages/Lab/LabFanout.vue
@@ -1,0 +1,202 @@
+<template>
+    <div class="p-8 max-w-3xl mx-auto">
+        <router-link
+            to="/lab"
+            class="text-sm text-blue-600 hover:underline"
+        >
+            ← Lab トップへ
+        </router-link>
+        <h1 class="mt-4 text-2xl font-bold">#3 SNS → SQS Fanout</h1>
+        <p class="mt-2 text-sm text-gray-500">
+            1 回の SNS <code class="rounded bg-gray-100 px-1">Publish</code> で
+            subscribe されている 2 つの SQS キュー（<code class="rounded bg-gray-100 px-1">lab-primary</code> /
+            <code class="rounded bg-gray-100 px-1">lab-audit</code>）に同じメッセージが配信される。
+            worker プロセスは両キューを独立した goroutine で long polling しており、
+            送信直後に両キューの visible 件数が +1 → 処理されて 0 に戻る挙動が観察できる。
+        </p>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <h2 class="font-semibold">Publish to SNS topic</h2>
+            <textarea
+                v-model="messageBody"
+                class="mt-2 w-full rounded border border-gray-300 p-2 font-mono text-sm"
+                rows="2"
+                placeholder="任意のメッセージ本文"
+            ></textarea>
+            <div class="mt-2 flex flex-wrap gap-2">
+                <button
+                    type="button"
+                    class="rounded bg-blue-600 px-4 py-2 text-sm text-white disabled:opacity-50"
+                    :disabled="!messageBody || busy"
+                    @click="publish(messageBody)"
+                >
+                    SNS Publish
+                </button>
+                <button
+                    type="button"
+                    class="rounded bg-gray-600 px-4 py-2 text-sm text-white disabled:opacity-50"
+                    :disabled="busy"
+                    @click="publishBurst"
+                >
+                    5 件 burst
+                </button>
+            </div>
+        </section>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <div class="flex items-center justify-between">
+                <h2 class="font-semibold">Queue Stats (fanout targets)</h2>
+                <label class="flex items-center gap-1 text-xs text-gray-600">
+                    <input
+                        v-model="autoRefresh"
+                        type="checkbox"
+                    />
+                    auto-refresh (2s)
+                </label>
+            </div>
+            <table class="mt-3 w-full text-sm">
+                <thead class="text-left text-xs text-gray-500">
+                    <tr>
+                        <th class="py-1">queue</th>
+                        <th class="py-1 text-right">visible</th>
+                        <th class="py-1 text-right">inFlight</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr
+                        v-for="q in stats"
+                        :key="q.name"
+                        class="border-t border-gray-100"
+                    >
+                        <td class="py-1 font-mono text-xs">{{ q.name }}</td>
+                        <td class="py-1 text-right">{{ q.visible }}</td>
+                        <td class="py-1 text-right">{{ q.inFlight }}</td>
+                    </tr>
+                    <tr v-if="!stats.length">
+                        <td
+                            class="py-2 text-xs text-gray-400"
+                            colspan="3"
+                        >
+                            stats 取得中…
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <p class="mt-2 text-xs text-gray-400">
+                ApproximateNumberOfMessages 系の値は結果整合性なので、数秒の
+                遅延がある。publish 直後は両キューがほぼ同時に +1 される。
+            </p>
+        </section>
+
+        <section
+            v-if="log.length"
+            class="mt-6 rounded-md border border-gray-200 p-4"
+        >
+            <h2 class="font-semibold">Log</h2>
+            <ul class="mt-2 max-h-48 overflow-auto rounded bg-gray-50 p-2 text-xs font-mono">
+                <li
+                    v-for="(line, i) in log"
+                    :key="i"
+                    :class="line.level === 'error' ? 'text-red-600' : 'text-gray-700'"
+                >
+                    [{{ line.level }}] {{ line.msg }}
+                </li>
+            </ul>
+        </section>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from "vue";
+import axios from "axios";
+
+type QueueStat = { name: string; visible: number; inFlight: number };
+type LogLine = { level: "info" | "error"; msg: string };
+
+const apiBase = import.meta.env.VITE_APP_API_BASE_URL as string;
+
+const messageBody = ref("hello from fanout");
+const busy = ref(false);
+const stats = ref<QueueStat[]>([]);
+const log = ref<LogLine[]>([]);
+const autoRefresh = ref(true);
+let timer: ReturnType<typeof setInterval> | null = null;
+
+const pushLog = (level: LogLine["level"], msg: string) => {
+    log.value.unshift({ level, msg });
+    if (log.value.length > 30) log.value.pop();
+};
+
+const loadStats = async () => {
+    try {
+        const { data } = await axios.get(`${apiBase}/lab/sns/stats`);
+        stats.value = data.queues ?? [];
+    } catch (e) {
+        pushLog(
+            "error",
+            `stats: ${e instanceof Error ? e.message : String(e)}`
+        );
+    }
+};
+
+const publish = async (body: string) => {
+    if (!body) return;
+    busy.value = true;
+    try {
+        const { data } = await axios.post(`${apiBase}/lab/sns/publish`, {
+            body,
+        });
+        pushLog("info", `published: ${data.messageId}`);
+        await loadStats();
+    } catch (e) {
+        pushLog(
+            "error",
+            `publish: ${e instanceof Error ? e.message : String(e)}`
+        );
+    } finally {
+        busy.value = false;
+    }
+};
+
+const publishBurst = async () => {
+    busy.value = true;
+    try {
+        for (let i = 1; i <= 5; i++) {
+            await axios.post(`${apiBase}/lab/sns/publish`, {
+                body: `burst ${i}/5 @ ${new Date().toISOString()}`,
+            });
+        }
+        pushLog("info", "burst 5 published");
+        await loadStats();
+    } catch (e) {
+        pushLog(
+            "error",
+            `burst: ${e instanceof Error ? e.message : String(e)}`
+        );
+    } finally {
+        busy.value = false;
+    }
+};
+
+const startTimer = () => {
+    if (timer) return;
+    timer = setInterval(loadStats, 2000);
+};
+const stopTimer = () => {
+    if (timer) {
+        clearInterval(timer);
+        timer = null;
+    }
+};
+
+watch(autoRefresh, (on) => {
+    if (on) startTimer();
+    else stopTimer();
+});
+
+onMounted(() => {
+    loadStats();
+    if (autoRefresh.value) startTimer();
+});
+onUnmounted(stopTimer);
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -26,6 +26,7 @@ import LabIndex from "../pages/Lab/LabIndex.vue";
 import LabPlaceholder from "../pages/Lab/LabPlaceholder.vue";
 import LabS3 from "../pages/Lab/LabS3.vue";
 import LabQueue from "../pages/Lab/LabQueue.vue";
+import LabFanout from "../pages/Lab/LabFanout.vue";
 
 import Error from "../pages/Error/Error.vue";
 import { createAxiosInstance } from "@/utils/axiosinstance";
@@ -207,8 +208,7 @@ const routes: RouteRecordRaw[] = [
     {
         path: "/lab/fanout",
         name: "LabFanout",
-        component: LabPlaceholder,
-        props: { title: "#3 SNS → SQS Fanout" },
+        component: LabFanout,
     },
     {
         path: "/lab/lambda",


### PR DESCRIPTION
## 実装概要

lab 第 3 弾フロント。`/lab/fanout` に SNS → SQS fanout の demo UI を実装。1 回の SNS publish で lab-primary / lab-audit 両キューの件数が同時に +1 される挙動を可視化する。

### 変更ファイル

- `src/pages/Lab/LabFanout.vue` — 新規ページ（publish フォーム + 2 キュー stats 表示）
- `src/router/index.ts` — `/lab/fanout` を `LabPlaceholder` から `LabFanout` に差し替え

### 画面構成

- **Publish**: メッセージ入力 + 「SNS Publish」「5 件 burst」ボタン
- **Queue Stats**: `lab-primary` / `lab-audit` の visible / inFlight を 2 秒間隔で自動更新
- **Log**: publish 結果・エラー表示

## 設計判断の「なぜ」

### なぜ 2 キューを 1 画面で並べて表示するか

fanout の本質は「**1 publish で複数キューに同時配信される**」こと。2 キューを縦並びにすることで、publish 直後に両方の visible が +1 → 処理されて 0 に戻る様子が視覚的に分かる。コンソールでログを追うより UX が良い。

### なぜ stats を poll にしたか（WebSocket / SSE ではなく）

- `ApproximateNumberOfMessages` は結果整合性で数秒遅延がある → リアルタイム push する意味が薄い
- 2 秒 poll なら人間が認識できる程度の粒度で十分
- lab なので最小実装を優先。リアルタイム push は `#10 SSE / WebSocket` で別途扱う

### なぜ `5 件 burst` ボタンを用意したか

single publish だと処理が速すぎて stats の上昇を捉えにくい。burst で visible が一時的に 5 まで上がる様子を観察しやすくする学習用の仕掛け。

## ハマりポイント・注意事項

### 1. stats の見かけ上の揺らぎ

`ApproximateNumberOfMessages` は SQS の結果整合性な値。publish 直後に stats を叩いても 0 のまま → 1〜2 秒後に反映、ということが普通に起きる。UI 上で「反映遅れ」を説明するキャプションを入れて混乱を避けている。

### 2. axios の Content-Type 自動付与は SNS publish では問題にならない

#1 S3 では axios の Content-Type 自動付与が署名と不一致を起こすため XHR を使ったが、SNS publish は自 backend API 経由なので axios でシンプルに POST でよい。

## 本番 AWS との差分・設定箇所

フロントエンドのコード変更は不要。本番で変わるのは:

- `.env.production` の `VITE_APP_API_BASE_URL` を本番 API URL に
- backend 側の SNS topic ARN が本番アカウントの ARN に（fanc-api 側の env で設定）

## Test plan

- [x] `npm run build` が通る（vue-tsc + vite build）
- [x] `/lab/fanout` が表示される
- [x] 「SNS Publish」押下 → messageId が log に出る
- [x] `lab-primary` / `lab-audit` の visible が両方 +1 → 0 に戻る
- [x] 「5 件 burst」で両キューが一時的に 5 まで積み上がる
- [x] auto-refresh トグル OFF で停止、ON で再開
- [x] モバイル幅でもレイアウトが崩れない

### 関連 PR

- Backend: fanc-api `feature/lab-sns-fanout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
