### PR TITLE
feat(lab): /lab/lambda に S3 → Lambda トリガーの UI を実装

### DIFF
--- a/src/pages/Lab/LabLambda.vue
+++ b/src/pages/Lab/LabLambda.vue
@@ -1,0 +1,293 @@
+<template>
+    <div class="p-8 max-w-3xl mx-auto">
+        <router-link
+            to="/lab"
+            class="text-sm text-blue-600 hover:underline"
+        >
+            ← Lab トップへ
+        </router-link>
+        <h1 class="mt-4 text-2xl font-bold">#4 Lambda (S3 → Lambda)</h1>
+        <p class="mt-2 text-sm text-gray-500">
+            <code class="rounded bg-gray-100 px-1">lab-lambda</code> バケットの
+            <code class="rounded bg-gray-100 px-1">uploads/</code> に PUT すると、
+            S3 イベント通知で Go Lambda が起動し、オブジェクトを GetObject →
+            SHA-256 / サイズ / Content-Type を計算して
+            <code class="rounded bg-gray-100 px-1">results/{key}.json</code> に書き戻す。
+            フロントは results を 2 秒おきに polling し、Lambda の処理完了を観察する。
+        </p>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <h2 class="font-semibold">アップロード</h2>
+            <div class="mt-3 flex items-center gap-3">
+                <input
+                    type="file"
+                    class="text-sm"
+                    @change="onFileChange"
+                />
+                <button
+                    type="button"
+                    class="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                    :disabled="!file || uploading"
+                    @click="upload"
+                >
+                    {{ uploading ? "アップロード中…" : "アップロード" }}
+                </button>
+            </div>
+            <div
+                v-if="file"
+                class="mt-3 text-xs text-gray-600"
+            >
+                選択中: {{ file.name }} ({{ humanSize(file.size) }})
+            </div>
+            <div
+                v-if="uploading || progress > 0"
+                class="mt-4"
+            >
+                <div class="h-2 w-full overflow-hidden rounded bg-gray-200">
+                    <div
+                        class="h-full bg-blue-500 transition-all"
+                        :style="{ width: progress + '%' }"
+                    />
+                </div>
+                <div class="mt-1 text-xs text-gray-500">
+                    {{ progress.toFixed(1) }}%
+                </div>
+            </div>
+            <ul
+                v-if="log.length"
+                class="mt-4 max-h-48 overflow-auto rounded bg-gray-50 p-2 text-xs font-mono"
+            >
+                <li
+                    v-for="(line, i) in log"
+                    :key="i"
+                    :class="line.level === 'error' ? 'text-red-600' : 'text-gray-700'"
+                >
+                    [{{ line.level }}] {{ line.msg }}
+                </li>
+            </ul>
+        </section>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <div class="flex items-center justify-between">
+                <h2 class="font-semibold">Uploads / Results</h2>
+                <label class="flex items-center gap-1 text-xs text-gray-600">
+                    <input
+                        v-model="autoRefresh"
+                        type="checkbox"
+                    />
+                    auto-refresh (2s)
+                </label>
+            </div>
+
+            <h3 class="mt-3 text-sm font-medium text-gray-700">
+                uploads/ ({{ uploads.length }})
+            </h3>
+            <table class="mt-1 w-full text-sm">
+                <thead class="text-left text-xs text-gray-500">
+                    <tr>
+                        <th class="py-1">key</th>
+                        <th class="py-1">size</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr
+                        v-for="obj in uploads"
+                        :key="obj.key"
+                        class="border-t border-gray-100"
+                    >
+                        <td class="py-1 font-mono text-xs">{{ obj.key }}</td>
+                        <td class="py-1">{{ humanSize(obj.size) }}</td>
+                    </tr>
+                    <tr v-if="!uploads.length">
+                        <td
+                            class="py-2 text-xs text-gray-400"
+                            colspan="2"
+                        >
+                            まだ何もない。
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3 class="mt-4 text-sm font-medium text-gray-700">
+                results/ ({{ results.length }})
+            </h3>
+            <div class="mt-1 space-y-2">
+                <div
+                    v-for="r in results"
+                    :key="r.key"
+                    class="rounded border border-gray-100 p-2 text-xs"
+                >
+                    <div class="font-mono text-gray-600">{{ r.key }}</div>
+                    <div
+                        v-if="r.payload"
+                        class="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 text-gray-700"
+                    >
+                        <div>size: {{ humanSize(r.payload.size) }}</div>
+                        <div>contentType: {{ r.payload.contentType || "-" }}</div>
+                        <div class="col-span-2">
+                            sha256:
+                            <span class="font-mono">{{ r.payload.sha256 }}</span>
+                        </div>
+                        <div class="col-span-2 text-gray-500">
+                            processedAt: {{ r.payload.processedAt }}
+                        </div>
+                    </div>
+                </div>
+                <div
+                    v-if="!results.length"
+                    class="text-xs text-gray-400"
+                >
+                    Lambda 処理結果はまだない（upload 後、数秒で出現する）。
+                </div>
+            </div>
+        </section>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import axios from "axios";
+
+type S3Object = { key: string; size: number; lastModified: string };
+type ResultPayload = {
+    key: string;
+    bucket: string;
+    size: number;
+    contentType: string;
+    sha256: string;
+    processedAt: string;
+};
+type Result = {
+    key: string;
+    size: number;
+    lastModified: string;
+    payload?: ResultPayload;
+};
+type LogLine = { level: "info" | "error"; msg: string };
+
+const apiBase = import.meta.env.VITE_APP_API_BASE_URL as string;
+
+const file = ref<File | null>(null);
+const uploading = ref(false);
+const uploadedBytes = ref(0);
+const uploads = ref<S3Object[]>([]);
+const results = ref<Result[]>([]);
+const log = ref<LogLine[]>([]);
+const autoRefresh = ref(true);
+let timer: ReturnType<typeof setInterval> | null = null;
+
+const progress = computed(() =>
+    file.value && file.value.size > 0
+        ? (uploadedBytes.value / file.value.size) * 100
+        : 0
+);
+
+const humanSize = (n: number) => {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+    if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MiB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)} GiB`;
+};
+
+const pushLog = (level: LogLine["level"], msg: string) => {
+    log.value.unshift({ level, msg });
+    if (log.value.length > 30) log.value.pop();
+};
+
+const onFileChange = (e: Event) => {
+    const input = e.target as HTMLInputElement;
+    file.value = input.files?.[0] ?? null;
+    uploadedBytes.value = 0;
+};
+
+const refresh = async () => {
+    try {
+        const [u, r] = await Promise.all([
+            axios.get(`${apiBase}/lab/lambda/uploads`),
+            axios.get(`${apiBase}/lab/lambda/results`),
+        ]);
+        uploads.value = u.data.uploads ?? [];
+        results.value = r.data.results ?? [];
+    } catch (e) {
+        pushLog(
+            "error",
+            `refresh: ${e instanceof Error ? e.message : String(e)}`
+        );
+    }
+};
+
+const upload = async () => {
+    if (!file.value) return;
+    const f = file.value;
+
+    uploading.value = true;
+    uploadedBytes.value = 0;
+
+    try {
+        pushLog(
+            "info",
+            `presign-put: ${f.name} (${humanSize(f.size)}, ${f.type || "application/octet-stream"})`
+        );
+        const { data } = await axios.post(
+            `${apiBase}/lab/lambda/presign-put`,
+            {
+                filename: f.name,
+                contentType: f.type || "application/octet-stream",
+            }
+        );
+        const url: string = data.url;
+        const key: string = data.key;
+        pushLog("info", `key=${key}`);
+
+        await new Promise<void>((resolve, reject) => {
+            const xhr = new XMLHttpRequest();
+            xhr.open("PUT", url);
+            xhr.upload.onprogress = (ev) => {
+                if (ev.lengthComputable) {
+                    uploadedBytes.value = ev.loaded;
+                }
+            };
+            xhr.onload = () => {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    uploadedBytes.value = f.size;
+                    resolve();
+                } else {
+                    reject(new Error(`PUT failed: HTTP ${xhr.status}`));
+                }
+            };
+            xhr.onerror = () => reject(new Error("PUT network error"));
+            xhr.send(f);
+        });
+
+        pushLog("info", "upload done — waiting for Lambda to process…");
+        await refresh();
+    } catch (err) {
+        pushLog("error", err instanceof Error ? err.message : String(err));
+    } finally {
+        uploading.value = false;
+    }
+};
+
+const startTimer = () => {
+    if (timer) return;
+    timer = setInterval(refresh, 2000);
+};
+const stopTimer = () => {
+    if (timer) {
+        clearInterval(timer);
+        timer = null;
+    }
+};
+
+watch(autoRefresh, (on) => {
+    if (on) startTimer();
+    else stopTimer();
+});
+
+onMounted(() => {
+    refresh();
+    if (autoRefresh.value) startTimer();
+});
+onUnmounted(stopTimer);
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -27,6 +27,7 @@ import LabPlaceholder from "../pages/Lab/LabPlaceholder.vue";
 import LabS3 from "../pages/Lab/LabS3.vue";
 import LabQueue from "../pages/Lab/LabQueue.vue";
 import LabFanout from "../pages/Lab/LabFanout.vue";
+import LabLambda from "../pages/Lab/LabLambda.vue";
 
 import Error from "../pages/Error/Error.vue";
 import { createAxiosInstance } from "@/utils/axiosinstance";
@@ -213,8 +214,7 @@ const routes: RouteRecordRaw[] = [
     {
         path: "/lab/lambda",
         name: "LabLambda",
-        component: LabPlaceholder,
-        props: { title: "#4 Lambda" },
+        component: LabLambda,
     },
     {
         path: "/lab/cache",


### PR DESCRIPTION
## 実装概要

lab 第 4 弾フロント。`/lab/lambda` に S3 → Lambda demo UI を実装。`lab-lambda` バケットに presigned PUT → LocalStack 上の Go Lambda が S3 イベント通知で起動 → `results/{key}.json` に書き戻す、という流れを可視化する。

### 変更ファイル

- `src/pages/Lab/LabLambda.vue` — 新規ページ (upload フォーム + uploads/results 2 段一覧)
- `src/router/index.ts` — `/lab/lambda` を `LabPlaceholder` から `LabLambda` に差し替え

### 画面構成

- **アップロード**: ファイル選択 + PUT 進捗バー + log
- **Uploads / Results**: `uploads/` と `results/` を 2 秒間隔で自動更新 (auto-refresh トグル付き)
  - results の payload (Lambda が書き戻した JSON) を展開表示: size / contentType / sha256 / processedAt

## 設計判断の「なぜ」

### なぜ uploads と results を 1 画面に縦並びで出すか

S3 → Lambda の体感の要は「**PUT した直後は uploads にだけあり、数秒後に results にも現れる**」という非同期処理の「間」を見せること。2 段並びにすることで、

1. upload 直後: uploads に 1 件、results は空
2. 数秒後: results にも 1 件（Lambda 完了）

という時系列が視覚的に分かる。

### なぜ poll(2s) で十分か

- Lambda の非同期 invoke はコールドスタートで 数百 ms 〜 数秒
- 2 秒 poll なら人間の「あ、処理された」という認識タイミングに合う
- SSE / WebSocket にすると backend / infra が一段複雑になり、lab スコープを超える
- lab 第 10 弾で SSE / WebSocket を扱うのでここでは詳細版は不要

### なぜ payload を frontend で展開表示するか

results の JSON を単なる「key 一覧」で終わらせると、Lambda が何を計算したかが見えない。SHA-256 の hex 表示まで見せることで「**この Lambda は中身を読んで hash を計算している**」のが一目で伝わる。backend が payload を一覧 API に含めて返してくれるので、フロントは追加の `GetObject` 相当を打たずに 1 リクエストで表示できる。

### なぜ XHR を使って axios を使わないか

#1 S3 と同じ理由: axios は Content-Type を自動で付けるため presigned URL の署名と不一致を起こすリスクがある。進捗イベント (`upload.onprogress`) も XHR なら自然に取れる。

## ハマりポイント・注意事項

### 1. Lambda のコールドスタート

初回 PUT の直後は Lambda が cold start で 1〜3 秒かかることがある。2 秒 poll だと「1 回 miss して次の poll で出現」するように見える。UI キャプションで「upload 後、数秒で出現する」と明示。

### 2. results の payload フォーマットが変わったら

現状の payload 型は backend の `Result` struct に依存している（key / bucket / size / contentType / sha256 / processedAt）。backend 側の struct が変わると型不整合になるので、必要なら shared TypeScript 型生成を検討（lab スコープでは手で揃える）。

## 本番 AWS との差分・設定箇所

フロントエンドコード変更は不要。本番で変わるのは:

- `.env.production` の `VITE_APP_API_BASE_URL`
- backend 側の S3 bucket 名 (`LAB_LAMBDA_BUCKET` env)

## Test plan

- [x] `npm run build` が通る (vue-tsc + vite build)
- [x] `/lab/lambda` が表示される
- [x] ファイルを選択 → 「アップロード」で PUT 成功
- [x] upload 直後は uploads に 1 件、results は空
- [x] 数秒後に results に JSON が現れ、sha256 / size / contentType / processedAt が表示される
- [x] auto-refresh OFF で停止、ON で再開
- [x] 連続 upload で uploads / results が共に増える
- [x] モバイル幅でもレイアウトが崩れない

### 関連 PR

- Backend: fanc-api `feature/lab-lambda`

🤖 Generated with [Claude Code](https://claude.com/claude-code)