### PR TITLE
feat(lab): /lab/partition で Postgres パーティション pruning を可視化

### DIFF
--- a/src/pages/Lab/LabPartition.vue
+++ b/src/pages/Lab/LabPartition.vue
@@ -1,0 +1,214 @@
+<template>
+    <div class="p-8 max-w-4xl mx-auto">
+        <router-link to="/lab" class="text-sm text-blue-600 hover:underline">
+            ← Lab トップへ
+        </router-link>
+        <h1 class="mt-4 text-2xl font-bold">#7 Postgres パーティショニング</h1>
+        <p class="mt-2 text-sm text-gray-500">
+            <code class="rounded bg-gray-100 px-1">events</code>
+            テーブルは
+            <code class="rounded bg-gray-100 px-1">event_at</code>
+            を key にした月次 RANGE パーティション（2025-11〜2026-04 +
+            default）。 1 万件のテスト data を投入済み。
+            <code class="rounded bg-gray-100 px-1"
+                >GET /lab/partition?from=&amp;to=</code
+            >
+            を叩くと件数・EXPLAIN ANALYZE に加え「どの partition が scan
+            されたか」 が返る。範囲を狭めていくと scan 対象の partition が減って
+            <span class="font-semibold">partition pruning</span>
+            の効果が視認できる。
+        </p>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <div class="flex flex-wrap items-end gap-3">
+                <label class="flex flex-col text-sm">
+                    <span class="text-xs text-gray-500">from</span>
+                    <input
+                        v-model="from"
+                        type="date"
+                        class="mt-1 rounded border border-gray-300 p-2 text-sm"
+                    />
+                </label>
+                <label class="flex flex-col text-sm">
+                    <span class="text-xs text-gray-500">to（未満）</span>
+                    <input
+                        v-model="to"
+                        type="date"
+                        class="mt-1 rounded border border-gray-300 p-2 text-sm"
+                    />
+                </label>
+                <button
+                    type="button"
+                    class="rounded bg-blue-600 px-4 py-2 text-sm text-white disabled:opacity-50"
+                    :disabled="busy || !from || !to"
+                    @click="runQuery"
+                >
+                    実行
+                </button>
+                <div class="flex gap-1 text-xs">
+                    <button
+                        type="button"
+                        class="rounded bg-gray-100 px-2 py-1 hover:bg-gray-200"
+                        @click="applyPreset('month')"
+                    >
+                        1 ヶ月
+                    </button>
+                    <button
+                        type="button"
+                        class="rounded bg-gray-100 px-2 py-1 hover:bg-gray-200"
+                        @click="applyPreset('quarter')"
+                    >
+                        3 ヶ月
+                    </button>
+                    <button
+                        type="button"
+                        class="rounded bg-gray-100 px-2 py-1 hover:bg-gray-200"
+                        @click="applyPreset('all')"
+                    >
+                        全範囲
+                    </button>
+                </div>
+            </div>
+            <p class="mt-3 text-xs text-gray-400">
+                from ≤ event_at &lt; to の半開区間。範囲を狭くすると scan される
+                partition が減る。
+            </p>
+        </section>
+
+        <section
+            v-if="result"
+            class="mt-6 rounded-md border border-gray-200 p-4"
+        >
+            <div class="flex flex-wrap items-center gap-4 text-sm">
+                <span>
+                    件数:
+                    <span class="font-semibold">{{ result.count }}</span>
+                </span>
+                <span>
+                    所要:
+                    <span class="font-semibold">{{ result.elapsedMs }} ms</span>
+                </span>
+                <span>
+                    scan 対象:
+                    <span class="font-semibold"
+                        >{{ result.scannedPartitions.length }} /
+                        {{ result.partitions.length }}</span
+                    >
+                </span>
+            </div>
+
+            <h2 class="mt-4 font-semibold">Partitions</h2>
+            <p class="text-xs text-gray-400">
+                青が scan されたもの、灰が pruning で枝刈りされたもの。
+            </p>
+            <ul class="mt-2 flex flex-wrap gap-2">
+                <li
+                    v-for="p in result.partitions"
+                    :key="p.name"
+                    class="rounded border px-2 py-1 font-mono text-xs"
+                    :class="
+                        p.scanned
+                            ? 'border-blue-400 bg-blue-50 text-blue-800'
+                            : 'border-gray-200 bg-gray-50 text-gray-400 line-through'
+                    "
+                >
+                    {{ p.name }}
+                </li>
+            </ul>
+
+            <h2 class="mt-4 font-semibold">EXPLAIN ANALYZE</h2>
+            <pre
+                class="mt-2 max-h-96 overflow-auto rounded bg-gray-900 p-3 text-xs text-gray-100"
+            ><code>{{ result.explain }}</code></pre>
+        </section>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <h2 class="font-semibold">Log</h2>
+            <ul
+                class="mt-2 max-h-48 overflow-auto rounded bg-gray-50 p-2 font-mono text-xs"
+            >
+                <li
+                    v-for="(line, i) in log"
+                    :key="i"
+                    :class="
+                        line.level === 'error'
+                            ? 'text-red-600'
+                            : 'text-gray-700'
+                    "
+                >
+                    [{{ line.level }}] {{ line.msg }}
+                </li>
+                <li v-if="!log.length" class="text-gray-400">
+                    実行するとここにログが出ます
+                </li>
+            </ul>
+        </section>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import axios from "axios";
+
+type Partition = { name: string; scanned: boolean };
+type PartitionResp = {
+    from: string;
+    to: string;
+    count: number;
+    elapsedMs: number;
+    partitions: Partition[];
+    scannedPartitions: string[];
+    explain: string;
+};
+type LogLine = { level: "info" | "error"; msg: string };
+
+const apiBase = import.meta.env.VITE_APP_API_BASE_URL as string;
+
+// seed のカバー範囲。初期値はその中から 1 ヶ月ぶん。
+const seedStart = "2025-11-01";
+const seedEnd = "2026-05-01";
+
+const from = ref("2026-02-01");
+const to = ref("2026-03-01");
+const result = ref<PartitionResp | null>(null);
+const log = ref<LogLine[]>([]);
+const busy = ref(false);
+
+const pushLog = (level: LogLine["level"], msg: string) => {
+    log.value.unshift({ level, msg });
+    if (log.value.length > 50) log.value.pop();
+};
+
+const applyPreset = (preset: "month" | "quarter" | "all") => {
+    if (preset === "month") {
+        from.value = "2026-02-01";
+        to.value = "2026-03-01";
+    } else if (preset === "quarter") {
+        from.value = "2026-01-01";
+        to.value = "2026-04-01";
+    } else {
+        from.value = seedStart;
+        to.value = seedEnd;
+    }
+};
+
+const runQuery = async () => {
+    busy.value = true;
+    try {
+        const { data } = await axios.get<PartitionResp>(
+            `${apiBase}/lab/partition`,
+            { params: { from: from.value, to: to.value } }
+        );
+        result.value = data;
+        pushLog(
+            "info",
+            `GET partition from=${from.value} to=${to.value} → ${data.count} rows / ${data.elapsedMs} ms / scanned ${data.scannedPartitions.length}`
+        );
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        pushLog("error", `query: ${msg}`);
+    } finally {
+        busy.value = false;
+    }
+};
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -30,6 +30,7 @@ import LabFanout from "../pages/Lab/LabFanout.vue";
 import LabLambda from "../pages/Lab/LabLambda.vue";
 import LabCache from "../pages/Lab/LabCache.vue";
 import LabRls from "../pages/Lab/LabRls.vue";
+import LabPartition from "../pages/Lab/LabPartition.vue";
 
 import Error from "../pages/Error/Error.vue";
 import { createAxiosInstance } from "@/utils/axiosinstance";
@@ -231,8 +232,7 @@ const routes: RouteRecordRaw[] = [
     {
         path: "/lab/partition",
         name: "LabPartition",
-        component: LabPlaceholder,
-        props: { title: "#7 Postgres パーティショニング" },
+        component: LabPartition,
     },
     {
         path: "/lab/bulk",


### PR DESCRIPTION
## 実装概要

fanc-lab カリキュラム #7 (Postgres パーティショニング) の UI 側。日付範囲を絞って `GET /api/lab/partition` を叩き、**scan 対象の partition が減っていく様子**をブラウザで視認できるようにした。

### 追加・変更点

| ファイル | 変更 |
|---------|------|
| `src/pages/Lab/LabPartition.vue` | 新規。日付範囲入力 + プリセット + partition ハイライト + EXPLAIN 表示 |
| `src/router/index.ts` | `/lab/partition` のマウント先を LabPlaceholder → LabPartition に差し替え |

### UI 構成

```
┌──────────────────────────────┐
│ from: [2026-02-01] to: [2026-03-01]  [実行]  [1ヶ月][3ヶ月][全範囲] │
├──────────────────────────────┤
│ 件数: 1552 / 所要: 98 ms / scan 対象: 1 / 7 │
│ Partitions: events_2025_11 events_2025_12 ...  ← 青 = scan / 灰 = pruning │
│ EXPLAIN ANALYZE: Seq Scan on events_2026_02 ... │
└──────────────────────────────┘
```

## 設計判断の「なぜ」

### 「どの partition が scan されたか」を UI で前面に出した

この lab で面接官に見せたいのは **partition pruning の効果**。API レベルでは EXPLAIN 出力に埋もれているが、初見で読み解けるものではないので:

1. 全 partition 名のバッジ一覧
2. scan されたものだけ青、pruning されたものは灰 + 打ち消し線

で「範囲を狭めると灰が増える」という挙動を一瞥で理解できるようにした。EXPLAIN 本文は横に併記するだけ。

### プリセット (1 ヶ月 / 3 ヶ月 / 全範囲) を用意した

手で日付を 2 箇所入力するのは億劫で、観察を阻害する。ワンクリックで範囲を広げ/狭めできると **pruning の階段** (1 → 3 → 6 partition) が連続的に見える。

### date input をあえて使っている

本番 UI なら v-calendar などを使うが、lab では **半開区間 `from ≤ event_at < to`** という SQL の約束を素直に表現したかったので、`<input type="date">` で開発者らしい見た目を残している。

### EXPLAIN 本文は monospace + 暗背景で表示

`Seq Scan on events_2026_02` のような構造化されたテキストは等幅フォントが読みやすい。`pre` + `bg-gray-900` で「SQL 結果らしい」見た目にしている。

## ハマりポイント

- **scan された partition 名の抽出は API 側で完結**: UI 側で EXPLAIN 文字列を parse するのは避け、API が `partitions[].scanned` で返す構造を信頼する。UI は render に集中
- **default partition の表示**: `events_default` は seed では使われないので常に灰。実運用で default に落ちていると「予期せず scan される」症状として目立つ
- **半開区間の説明を UI に入れる**: `from ≤ event_at < to` の半開区間を明示しないと、面接官に「to 含めて取りたい時は？」と突っ込まれる

## Test plan

- [ ] `/lab/partition` にアクセス → 初期値 (2026-02-01 〜 2026-03-01) で「実行」 → 1 つだけ青 (events_2026_02)、他は灰
- [ ] 「3 ヶ月」プリセット → 3 partition が青
- [ ] 「全範囲」プリセット → 6 partition が青、events_default は灰のまま
- [ ] 件数 / 所要 ms / EXPLAIN ANALYZE 本文が表示される
- [ ] エラー時は Log セクションに赤文字で出る

関連 API PR: kudotaka0421/fanc-api#80

🤖 Generated with [Claude Code](https://claude.com/claude-code)