### PR TITLE
feat(lab): #8 Postgres Bulk UI（COPY / INSERT ループ切替 + 所要時間比較）

### DIFF
--- a/src/pages/Lab/LabBulk.vue
+++ b/src/pages/Lab/LabBulk.vue
@@ -1,0 +1,258 @@
+<template>
+    <div class="p-8 max-w-4xl mx-auto">
+        <router-link to="/lab" class="text-sm text-blue-600 hover:underline">
+            ← Lab トップへ
+        </router-link>
+        <h1 class="mt-4 text-2xl font-bold">#8 Postgres Bulk</h1>
+        <p class="mt-2 text-sm text-gray-500">
+            CSV (<code class="rounded bg-gray-100 px-1"
+                >name,email,score</code
+            >) を backend に送り、
+            <span class="font-semibold">pgx.CopyFrom (COPY FROM STDIN)</span> と
+            <span class="font-semibold">1 件ずつの INSERT ループ</span>
+            で同じデータを投入して所要時間を比較する。件数を増やすほど COPY
+            が圧倒する。
+        </p>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <h2 class="font-semibold">CSV 準備</h2>
+            <p class="mt-1 text-xs text-gray-500">
+                ファイルを選ぶか、件数を指定してブラウザ側で合成する（いちいち CSV
+                を手作りするのが面倒なので用意）。
+            </p>
+            <div class="mt-3 flex flex-wrap items-center gap-3 text-sm">
+                <input type="file" accept=".csv" @change="onFileChange" />
+                <span class="text-gray-400">or</span>
+                <label class="flex items-center gap-1">
+                    <span class="text-xs text-gray-500">生成件数</span>
+                    <input
+                        v-model.number="genCount"
+                        type="number"
+                        min="1"
+                        max="100000"
+                        class="w-24 rounded border border-gray-300 p-1 text-sm"
+                    />
+                </label>
+                <button
+                    type="button"
+                    class="rounded bg-gray-100 px-3 py-1 text-xs hover:bg-gray-200"
+                    @click="generateCSV"
+                >
+                    生成してセット
+                </button>
+                <span v-if="file" class="text-xs text-gray-600">
+                    {{ file.name }} ({{ humanSize(file.size) }})
+                </span>
+            </div>
+        </section>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <h2 class="font-semibold">投入</h2>
+            <div class="mt-3 flex flex-wrap items-center gap-3 text-sm">
+                <div class="inline-flex rounded border border-gray-300">
+                    <button
+                        type="button"
+                        class="px-3 py-1 text-xs"
+                        :class="
+                            method === 'copy'
+                                ? 'bg-blue-600 text-white'
+                                : 'bg-white text-gray-700'
+                        "
+                        @click="method = 'copy'"
+                    >
+                        COPY 方式
+                    </button>
+                    <button
+                        type="button"
+                        class="border-l border-gray-300 px-3 py-1 text-xs"
+                        :class="
+                            method === 'insert'
+                                ? 'bg-blue-600 text-white'
+                                : 'bg-white text-gray-700'
+                        "
+                        @click="method = 'insert'"
+                    >
+                        INSERT ループ
+                    </button>
+                </div>
+                <button
+                    type="button"
+                    class="rounded bg-blue-600 px-4 py-2 text-sm text-white disabled:opacity-50"
+                    :disabled="busy || !file"
+                    @click="runImport"
+                >
+                    投入を実行
+                </button>
+                <button
+                    type="button"
+                    class="rounded bg-gray-100 px-3 py-2 text-xs hover:bg-gray-200"
+                    @click="fetchCount"
+                >
+                    現在件数を確認
+                </button>
+                <span v-if="count !== null" class="text-xs text-gray-500">
+                    bulk_samples: {{ count }} 行
+                </span>
+            </div>
+            <p class="mt-3 text-xs text-gray-400">
+                投入前に backend 側で <code>TRUNCATE</code>
+                するので、実行のたびに「 0 行から全件投入」で時間を比較できる。
+            </p>
+        </section>
+
+        <section
+            v-if="results.length"
+            class="mt-6 rounded-md border border-gray-200 p-4"
+        >
+            <h2 class="font-semibold">結果（新しい順）</h2>
+            <table class="mt-2 w-full text-sm">
+                <thead class="text-left text-xs text-gray-500">
+                    <tr>
+                        <th class="py-1">method</th>
+                        <th class="py-1">rows</th>
+                        <th class="py-1">elapsed</th>
+                        <th class="py-1">rows/ms</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr
+                        v-for="(r, i) in results"
+                        :key="i"
+                        class="border-t border-gray-100"
+                    >
+                        <td class="py-1 font-mono">
+                            <span
+                                class="rounded px-2 py-0.5 text-xs"
+                                :class="
+                                    r.method === 'copy'
+                                        ? 'bg-green-100 text-green-800'
+                                        : 'bg-orange-100 text-orange-800'
+                                "
+                            >
+                                {{ r.method }}
+                            </span>
+                        </td>
+                        <td class="py-1">{{ r.rows }}</td>
+                        <td class="py-1 font-semibold">
+                            {{ r.elapsedMs }} ms
+                        </td>
+                        <td class="py-1 text-gray-600">{{ r.rowsPerMs }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section class="mt-6 rounded-md border border-gray-200 p-4">
+            <h2 class="font-semibold">Log</h2>
+            <ul
+                class="mt-2 max-h-48 overflow-auto rounded bg-gray-50 p-2 font-mono text-xs"
+            >
+                <li
+                    v-for="(line, i) in log"
+                    :key="i"
+                    :class="
+                        line.level === 'error'
+                            ? 'text-red-600'
+                            : 'text-gray-700'
+                    "
+                >
+                    [{{ line.level }}] {{ line.msg }}
+                </li>
+                <li v-if="!log.length" class="text-gray-400">
+                    実行するとここにログが出ます
+                </li>
+            </ul>
+        </section>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import axios from "axios";
+
+type Method = "copy" | "insert";
+type ImportResp = {
+    method: Method;
+    rows: number;
+    elapsedMs: number;
+    rowsPerMs: string;
+};
+type CountResp = { count: number };
+type LogLine = { level: "info" | "error"; msg: string };
+
+const apiBase = import.meta.env.VITE_APP_API_BASE_URL as string;
+
+const file = ref<File | null>(null);
+const method = ref<Method>("copy");
+const genCount = ref(10000);
+const results = ref<ImportResp[]>([]);
+const count = ref<number | null>(null);
+const log = ref<LogLine[]>([]);
+const busy = ref(false);
+
+const pushLog = (level: LogLine["level"], msg: string) => {
+    log.value.unshift({ level, msg });
+    if (log.value.length > 50) log.value.pop();
+};
+
+const humanSize = (n: number) => {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${(n / 1024 / 1024).toFixed(1)} MB`;
+};
+
+const onFileChange = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    file.value = target.files?.[0] ?? null;
+};
+
+// CSV 手作りが面倒なのでブラウザで合成してそのまま File にしてセットする。
+// name / email は決定的に、score だけランダムにしておけば内容は十分。
+const generateCSV = () => {
+    const n = Math.max(1, Math.min(100000, genCount.value | 0));
+    const lines = ["name,email,score"];
+    for (let i = 1; i <= n; i++) {
+        const score = Math.floor(Math.random() * 100);
+        lines.push(`user${i},user${i}@example.com,${score}`);
+    }
+    const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+    file.value = new File([blob], `bulk_${n}.csv`, { type: "text/csv" });
+    pushLog("info", `generated CSV: ${n} rows`);
+};
+
+const runImport = async () => {
+    if (!file.value) return;
+    busy.value = true;
+    try {
+        const form = new FormData();
+        form.append("file", file.value);
+        form.append("method", method.value);
+        const { data } = await axios.post<ImportResp>(
+            `${apiBase}/lab/bulk`,
+            form
+        );
+        results.value.unshift(data);
+        if (results.value.length > 20) results.value.pop();
+        pushLog(
+            "info",
+            `import method=${data.method} rows=${data.rows} elapsed=${data.elapsedMs}ms rows/ms=${data.rowsPerMs}`
+        );
+        await fetchCount();
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        pushLog("error", `import: ${msg}`);
+    } finally {
+        busy.value = false;
+    }
+};
+
+const fetchCount = async () => {
+    try {
+        const { data } = await axios.get<CountResp>(`${apiBase}/lab/bulk/count`);
+        count.value = data.count;
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        pushLog("error", `count: ${msg}`);
+    }
+};
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -31,6 +31,7 @@ import LabLambda from "../pages/Lab/LabLambda.vue";
 import LabCache from "../pages/Lab/LabCache.vue";
 import LabRls from "../pages/Lab/LabRls.vue";
 import LabPartition from "../pages/Lab/LabPartition.vue";
+import LabBulk from "../pages/Lab/LabBulk.vue";
 
 import Error from "../pages/Error/Error.vue";
 import { createAxiosInstance } from "@/utils/axiosinstance";
@@ -237,8 +238,7 @@ const routes: RouteRecordRaw[] = [
     {
         path: "/lab/bulk",
         name: "LabBulk",
-        component: LabPlaceholder,
-        props: { title: "#8 Postgres Bulk" },
+        component: LabBulk,
     },
     {
         path: "/lab/breaker",


### PR DESCRIPTION
fanc-lab カリキュラム #8 のフロント実装。`/lab/bulk` に CSV 投入 + COPY / INSERT ループ切替 + 所要時間比較ページを追加。対応 API: [fanc-api#81](https://github.com/kudotaka0421/fanc-api/pull/81)。

## 実装概要

| ファイル | 変更 |
|---|---|
| `src/pages/Lab/LabBulk.vue` | 新規。CSV 選択 or ブラウザ合成 + 方式トグル + 結果テーブル + 件数取得 |
| `src/router/index.ts` | `/lab/bulk` を `LabPlaceholder` から `LabBulk` に差し替え |

### UI の流れ

1. 「CSV 準備」: 手元の CSV をアップロード、または件数を指定してブラウザ側で `name,email,score` CSV を合成（`Blob` → `File`）。
2. 「投入」: `COPY 方式` / `INSERT ループ` トグル + 実行ボタン。
3. 「結果」: 実行するたびに履歴が積まれるテーブル（method / rows / elapsed / rows per ms）。method 色分け（COPY 緑、INSERT 橙）で一目比較。
4. 「現在件数」ボタンで `GET /lab/bulk/count` を叩いて bulk_samples の行数を確認。

## 設計判断の「なぜ」

### なぜブラウザ側に CSV 合成ボタンを入れたか

毎回 10k 行 / 100k 行の CSV を手で用意するのはテンポが悪い。`Blob` + `File` API でサクッと合成して `FormData` にそのまま乗せられるので、実装コストほぼゼロで UX が跳ねる。フィールド内容（`user{i}@example.com` + 乱数 score）は固定の決定論 + 1 列乱数で十分。

### なぜ結果は履歴テーブル形式か

`COPY` ↔ `INSERT ループ` を行き来して比較するのが目的。単一表示にすると直前しか見えず毎回スクショを撮る羽目になる。履歴を unshift で積む形にして、直近 20 件で自動トリム。

### なぜ LabPlaceholder からの差し替えだけにしたか

既存ルート構造（`LabPlaceholder` → 実装ファイル）を踏襲。カリキュラム進捗表の UX とも揃うので最小変更で足りる。

## 本番で考えること（lab では省略）

- ブラウザ側 CSV 合成は 100k 行で数 MB の Blob を一気に確保する。本番では chunk 分割アップロード / Web Worker でメモリ圧迫を回避する。
- 進捗バー未実装（axios.onUploadProgress を入れるだけで出せるが、lab は計測できれば十分）。
- FormData の Content-Type は axios が自動付与（手で multipart/form-data を指定すると boundary 欠落で壊れる落とし穴あり）。

## 面接で話せるポイント

- File API と FormData で boundary を axios に任せる基本形。
- 大量ファイルアップロードは chunk + 並列 + retry の設計が別途必要（本 lab はスコープ外）。

## ハマりポイント

- Blob から File を作る際は 3 引数形式 `new File([blob], name, { type })` を徹底。
- LabPlaceholder を使う既存ルートは component + props セットなので、差し替え時は 2 行丸ごと書き換える。

## Test plan

- [x] vue-tsc --noEmit パス（型エラーなし）
- [ ] npm run dev で /lab/bulk を開き、合成ボタン → COPY → 結果が 1 行追加されることを確認
- [ ] INSERT ループに切り替えて再実行、所要時間が COPY より大きいことを確認
- [ ] 件数確認ボタンで投入件数が反映されることを確認

※ 手元で Docker の disk 不足により Postgres が recovery loop に入っており、実 API との結合確認は未実施（対応 PR 説明参照）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)